### PR TITLE
Open dump

### DIFF
--- a/src/rp2040_bringup.c
+++ b/src/rp2040_bringup.c
@@ -106,7 +106,9 @@ static int panic_open_dump_valve(struct notifier_block *nb, unsigned long action
         return -1;
     }
 
-    return ioctl(fd, PWMIOC_START, NULL);
+    err = ioctl(fd, PWMIOC_START, NULL);
+    up_udelay(1e6);
+    return err;
 }
 #endif
 


### PR DESCRIPTION
Tested on the pad box and confirmed that it does not affect the existing valve abort, and used the pico scope to confirm that the signal to open the dump valve is sent out for a quick pulse.

Did not test with the real dump valve attached because of mess in the bay, but can be tested before static fire when fill panel is out.